### PR TITLE
Use `yaml.safe_dump` to encode the secrets file

### DIFF
--- a/encryption.py
+++ b/encryption.py
@@ -1,3 +1,4 @@
+import yaml
 from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes
 
@@ -18,7 +19,7 @@ def encrypt(message, key):
 def write_to_yaml(key, nonce, tag, length, file_path="example/secrets.yaml"):
     """Writes key information to a yaml file"""
     with open(file_path, 'w') as f:
-        f.write(f"secrets:\n  key: {key}\n  nonce: {nonce}\n  tag: {tag}\n  length: {length}")
+        yaml.safe_dump(dict(secrets=dict(key=key, nonce=nonce, tag=tag, length=length)), f)
 
 
 def decrypt(nonce, ciphertext, tag, key):

--- a/open_yaml.py
+++ b/open_yaml.py
@@ -6,8 +6,8 @@ def read_yaml_file(file_path="keys/secrets.yaml"):
     with open(file_path, 'r') as file:
         yaml_data = yaml.safe_load(file)
         secrets = yaml_data["secrets"]
-        key = eval(secrets["key"].encode('utf-8'))
-        nonce = eval(secrets["nonce"].encode('utf-8'))
-        tag = eval(secrets["tag"].encode('utf-8'))
-        length = int(secrets["length"])
+        key = secrets["key"]
+        nonce = secrets["nonce"]
+        tag = secrets["tag"]
+        length = secrets["length"]
     return key, nonce, tag, length


### PR DESCRIPTION
A malicious YAML file could execute arbitrary code using eval, such as given below. Changed `write_to_yaml` and `read_yaml_file` to use yaml safe dump/load which accept bytes objects.

```yaml
secrets:
  key: (exec('import tkinter as tk;root=tk.Toplevel();root.title("will there be any evals this week");label=tk.Label(root,text="no, there will NOT be any evals this week");label.pack(expand=True,fill="both",padx=50,pady=50)'),b'If5\xc4/X\xc3\xce\xa5/\xb1\xf4\x83n\xa0\x98')[1]
  nonce: b'\xa9\x941\x1a\xfdm\xdek%\x0er2\xa8\xb6\xc2\xd0'
  tag: b'\xd54~\xb4^\xe8$V \xd5\xe3R\x07\xaf\x9b='
  length: 568
```
